### PR TITLE
Add archive notice and remove email signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
       <div class="container">
         <h1>High Performance Core Data</h1>
 
+        <div class="alert alert-info" role="alert">
+          <strong>Note:</strong> This page was last updated in 2013 and is no longer being maintained. The resources listed here are still accurate and relevant.
+        </div>
+
         <p>Below you will find a collection of resources for making Core Data fast.</p>
 
         <em>Learn how to analyze, debug, and squeeze every last bit of performance out of Core Data. The standard Core Data implementation is very powerful and flexible but lacks performance. This advanced talk covers various performance analysis tools, data model optimization, and various high performance concurrency models. This is an advanced discussion that assumes you have used Core Data before.</em>
@@ -75,31 +79,6 @@
 
         <div class="slides">
           <script async class="speakerdeck-embed" data-id="360691a030570131a0a76af09d9fc329" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
-        </div>
-
-        <br>
-        <br>
-        <br>
-
-        <p>I will be updating these resources as I discover new things about Core Data. If you would like to receive an email update, sign up below.</p>
-
-        <div class="center-block">
-          <!-- Begin MailChimp Signup Form -->
-          <link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
-          <style type="text/css">
-            #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif;  width:400px;}
-            /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
-               We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-          </style>
-          <div id="mc_embed_signup">
-          <form action="http://highperformancecoredata.us3.list-manage2.com/subscribe/post?u=95f955e27438bc37739fd0f89&amp;id=a261b52329" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <label for="mce-EMAIL">Subscribe for future updates</label>
-            <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-            <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-          </form>
-          </div>
-
-          <!--End mc_embed_signup-->
         </div>
 
         <hr>


### PR DESCRIPTION
## Summary
- Add a Bootstrap \`alert-info\` notice at the top of the page stating it was last updated in 2013 and is no longer being maintained, but the resources are still accurate.
- Remove the MailChimp email signup form (no longer running a newsletter).

## Why \`gh-pages\` not \`master\`?
GitHub Pages serves from the \`gh-pages\` branch (configured under repo Settings → Pages). \`master\` and \`gh-pages\` are nearly identical (only \`CNAME\` differs), but only \`gh-pages\` is deployed. After this merges, the two branches will diverge by one more file (\`index.html\`).

If you want \`master\` to stay in sync, easiest is to merge \`gh-pages\` back into \`master\` after this PR lands. Or longer-term, switch the Pages source to \`master\` and delete \`gh-pages\` to remove the duality.

## Test plan
- [ ] After merge, visit https://highperformancecoredata.com/ and confirm the blue note appears at the top
- [ ] Confirm the email signup is gone from the bottom
- [ ] Spot-check rest of page renders correctly (books, articles, videos, slides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)